### PR TITLE
v0.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VERSION="v0.3"
+VERSION="v0.4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   }
   ```
 
+## [v0.4](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.4) - 2021-03-08
+
+Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
+the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
+only available for Python 3.6 or more.
+
+### Added
+
+- Users's FindByContext class. Now, _pyopenproject_ can requests a user by its context.
+
+## [v0.4-beta.1](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.4-beta.1) - 2021-03-08
+
+Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
+the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
+only available for Python 3.6 or more.
+
+### Added
+
+- Users's FindByContext class. Now, _pyopenproject_ can requests a user by its context.
+
 ## [v0.3](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.3) - 2021-03-03
 
 Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ env_up:
 
 pytest:
 	- ${PYTHON} -m coverage run -m unittest discover -s ./tests/test_cases -t tests/test_cases -p *_test.py
-	- ${PYTHON} -m coverage report -m
 
 env_down:
 	cd ./tests/infra && \

--- a/pyopenproject/business/services/command/user/find_by_context.py
+++ b/pyopenproject/business/services/command/user/find_by_context.py
@@ -8,6 +8,12 @@ from pyopenproject.model.user import User
 class FindByContext(UserCommand):
 
     def __init__(self, connection, context):
+        """
+        Contructor for class FindByContext, from UserCommand
+
+        :param connection: The connection data
+        :param context: The user's url context
+        """
         super().__init__(connection)
         self.context = context
 

--- a/pyopenproject/business/services/command/user/find_by_context.py
+++ b/pyopenproject/business/services/command/user/find_by_context.py
@@ -1,0 +1,19 @@
+from pyopenproject.api_connection.exceptions.request_exception import RequestError
+from pyopenproject.api_connection.requests.get_request import GetRequest
+from pyopenproject.business.exception.business_error import BusinessError
+from pyopenproject.business.services.command.user.user_command import UserCommand
+from pyopenproject.model.user import User
+
+
+class FindByContext(UserCommand):
+
+    def __init__(self, connection, context):
+        super().__init__(connection)
+        self.context = context
+
+    def execute(self):
+        try:
+            json_obj = GetRequest(self.connection, f"{self.context}").execute()
+            return User(json_obj)
+        except RequestError as re:
+            raise BusinessError(f"Error finding user by context: {self.context}") from re

--- a/pyopenproject/business/services/user_service_impl.py
+++ b/pyopenproject/business/services/user_service_impl.py
@@ -2,6 +2,7 @@ from pyopenproject.business.services.command.user.create import Create
 from pyopenproject.business.services.command.user.delete import Delete
 from pyopenproject.business.services.command.user.find import Find
 from pyopenproject.business.services.command.user.find_all import FindAll
+from pyopenproject.business.services.command.user.find_by_context import FindByContext
 from pyopenproject.business.services.command.user.invite import Invite
 from pyopenproject.business.services.command.user.lock import Lock
 from pyopenproject.business.services.command.user.unlock import Unlock
@@ -25,6 +26,9 @@ class UserServiceImpl(UserService):
 
     def find(self, user):
         return Find(self.connection, user).execute()
+
+    def find_by_context(self, context):
+        return FindByContext(self.connection, context).execute()
 
     def update(self, user):
         return Update(self.connection, user).execute()

--- a/pyopenproject/business/user_service.py
+++ b/pyopenproject/business/user_service.py
@@ -20,6 +20,9 @@ class UserService(AbstractService):
     def find(self, user): raise NotImplementedError
 
     @abstractmethod
+    def find_by_context(self, context): raise NotImplementedError
+
+    @abstractmethod
     def lock(self, user): raise NotImplementedError
 
     @abstractmethod

--- a/tests/test_cases/user_service_test.py
+++ b/tests/test_cases/user_service_test.py
@@ -42,6 +42,12 @@ class UserServiceTestCase(OpenProjectTestCase):
         expected = self.usrSer.find(self.user)
         self.assertEqual(self.user.name, expected.name)
 
+    def test_find_by_context(self):
+        current = self.usrSer.find(self.user)
+        expected = self.usrSer.find_by_context(self.user.__dict__["_links"]["self"]["href"])
+        self.assertEqual(self.user.name, expected.name)
+        self.assertEqual(current.__dict__, expected.__dict__)
+
     def test_not_found(self):
         user = User({"id": 50})
         # Result is 404


### PR DESCRIPTION
Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
only available for Python 3.6 or more.

### Added

- Users's FindByContext class. Now, _pyopenproject_ can requests a user by its context.