### PR TITLE
New release v0.7

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VERSION="v0.6"
+VERSION="v0.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   }
   ```
 
+## [v0.7](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7) - 2021-03-22
+
+Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
+the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
+only available for Python 3.6 or more.
+
+### Changed
+
+- Invite user. Now, the required parameter is the e-mail.
+
+
+## [v0.7-beta.1](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7-beta.1) - 2021-03-22
+
+Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
+the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
+only available for Python 3.6 or more.
+
+### Changed
+
+- Invite user. Now, the required parameter is the e-mail.
+
 ## [v0.6](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.6) - 2021-03-19
 
 Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with

--- a/pyopenproject/business/services/command/user/invite.py
+++ b/pyopenproject/business/services/command/user/invite.py
@@ -7,19 +7,32 @@ from pyopenproject.model import user  as usr
 
 class Invite(UserCommand):
 
-    def __init__(self, connection, first_name, email):
+    def __init__(self, connection, email, login, first_name, last_name, admin, language):
         """Constructor for class Invite, from UserCommand
 
         :param connection: The connection data
-        :param first_name: The user's first name
         :param email: The users's email address
+        :param login: The user's login
+        :param first_name: The user's first name
+        :param last_name: The user's last name
+        :param admin: True if the user is an admin
+        :param language: The application language for the user
+
         """
         super().__init__(connection)
         self.user = {
             "email": email,
-            "firstName": first_name,
+            "admin": admin,
+            "language": language,
             "status": "invited"
         }
+        if login:
+            self.user["login"] = login
+        if first_name:
+            self.user["firstName"] = first_name
+        if last_name:
+            self.user["lastName"] = last_name
+
 
     def execute(self):
         try:

--- a/pyopenproject/business/services/user_service_impl.py
+++ b/pyopenproject/business/services/user_service_impl.py
@@ -39,5 +39,5 @@ class UserServiceImpl(UserService):
     def create(self, login, email, first_name, last_name, admin, language, status, password):
         return Create(self.connection, login, email, first_name, last_name, admin, language, status, password).execute()
 
-    def invite(self, first_name, email):
-        return Invite(self.connection, first_name, email).execute()
+    def invite(self, email, login=None, first_name=None, last_name=None, admin=False, language="EN"):
+        return Invite(self.connection, email, login, first_name, last_name, admin, language).execute()

--- a/pyopenproject/business/user_service.py
+++ b/pyopenproject/business/user_service.py
@@ -46,4 +46,4 @@ class UserService(AbstractService):
                password): raise NotImplementedError
 
     @abstractmethod
-    def invite(self, first_name, email): raise NotImplementedError
+    def invite(self, email, login, fist_name, last_name, admin, language): raise NotImplementedError


### PR DESCRIPTION
## [v0.7](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7) - 2021-03-22

Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
only available for Python 3.6 or more.

### Changed

- Invite user. Now, the required parameter is the e-mail.


## [v0.7-beta.1](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7-beta.1) - 2021-03-22

Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
only available for Python 3.6 or more.

### Changed

- Invite user. Now, the required parameter is the e-mail.