### PR TITLE
New release v0.7.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VERSION="v0.7.1"
+VERSION="v0.7.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,36 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   }
   ```
   
+## [v0.7.2](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7.2) - 2021-03-22
+
+Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
+the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
+only available for Python 3.6 or more.
+
+### Fixed
+
+- Folder tree changed in order to make the imports like:
+
+```python
+from pyopenproject import OpenProject
+from openproject.model import WorkPackage
+```
+
+## [v0.7.2-beta.1](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7.2-beta.1) - 2021-03-22
+
+Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
+the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
+only available for Python 3.6 or more.
+
+### Changed
+
+- Folder tree changed in order to make the imports like:
+
+```python
+from pyopenproject import OpenProject
+from openproject.model import WorkPackage
+```
+
 ## [v0.7.1](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7.1) - 2021-03-22
 
 Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with


### PR DESCRIPTION
## [v0.7.2](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7.2) - 2021-03-22

Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
only available for Python 3.6 or more.

### Fixed

- Folder tree changed in order to make the imports like:

```python
from pyopenproject import OpenProject
from openproject.model import WorkPackage
```

## [v0.7.2-beta.1](https://github.com/Flying-Free/pyopenproject/releases/tag/v0.7.2-beta.1) - 2021-03-22

Beta version of pyopenproject library. This library is a way to enable Python developers to communicate with
the [OpenProject API](https://docs.openproject.org/api/) with simplicity. Take in consideration that this development is
only available for Python 3.6 or more.

### Changed

- Folder tree changed in order to make the imports like:

```python
from pyopenproject import OpenProject
from openproject.model import WorkPackage
```