### PR TITLE
Quick Fix for the pain of wanting control over my tls session. It's my TLS-Session after all, mine alone!

### DIFF
--- a/pyopenproject/api_connection/requests/delete_request.py
+++ b/pyopenproject/api_connection/requests/delete_request.py
@@ -13,5 +13,5 @@ class DeleteRequest(Request):
         with requests.Session() as s:
             s.auth = HTTPBasicAuth(self.connection.api_user, self.connection.api_key)
             s.headers.update({'Content-Type': 'application/json;charset=utf-8'})
-            response = s.delete(url=self.connection.url_base + self.context)
+            response = s.delete(url=self.connection.url_base + self.context, **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/get_request.py
+++ b/pyopenproject/api_connection/requests/get_request.py
@@ -13,5 +13,5 @@ class GetRequest(Request):
         with requests.Session() as s:
             s.auth = HTTPBasicAuth(self.connection.api_user, self.connection.api_key)
             s.headers.update({"Content-Type": "application/hal+json"})
-            response = s.get(self.connection.url_base + self.context)
+            response = s.get(self.connection.url_base + self.context, **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/patch_request.py
+++ b/pyopenproject/api_connection/requests/patch_request.py
@@ -13,5 +13,5 @@ class PatchRequest(Request):
         with requests.Session() as s:
             s.auth = HTTPBasicAuth(self.connection.api_user, self.connection.api_key)
             s.headers.update({"Content-Type": "application/json"})
-            response = s.patch(self.connection.url_base + self.context, json=self.json)
+            response = s.patch(self.connection.url_base + self.context, json=self.json, **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/post_request.py
+++ b/pyopenproject/api_connection/requests/post_request.py
@@ -17,5 +17,6 @@ class PostRequest(Request):
                 url=self.connection.url_base + self.context,
                 json=self.json,
                 files=self.files,
-                data=self.data)
+                data=self.data,
+                **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/put_request.py
+++ b/pyopenproject/api_connection/requests/put_request.py
@@ -13,5 +13,6 @@ class PutRequest(Request):
             self.connection.url_base + self.context,
             auth=HTTPBasicAuth(self.connection.api_user, self.connection.api_key),
             data=self.json,
-            headers=self.headers
+            headers=self.headers,
+            **self.connection.request_args
         )

--- a/pyopenproject/model/connection.py
+++ b/pyopenproject/model/connection.py
@@ -6,13 +6,14 @@ class Connection:
     Class Configuration,
     represents the connection realized with the web application
     """
-    def __init__(self, url, apikey, user=None):
+    def __init__(self, url, apikey, user=None, **kwargs):
         """Constructor for class Connection
         :param url: The application url
         :param apikey: The apikey
         :param user: The user (optional)
         """
         self.url_base = url
+        self.request_args = kwargs
         self.api_user = "apikey" if user is None else user
         self.api_key = apikey
 

--- a/pyopenproject/openproject.py
+++ b/pyopenproject/openproject.py
@@ -35,10 +35,10 @@ from pyopenproject.model.connection import Connection
 
 class OpenProject:
 
-    def __init__(self, url, api_key, user=None):
-        self.conn = Connection(url=url, apikey=api_key) \
+    def __init__(self, url, api_key, user=None, **kwargs):
+        self.conn = Connection(url=url, apikey=api_key, **kwargs) \
             if user is None \
-            else Connection(url=url, user=user, apikey=api_key)
+            else Connection(url=url, user=user, apikey=api_key, **kwargs)
 
     def get_activity_service(self):
         return ActivityServiceImpl(self.conn)


### PR DESCRIPTION
A quick and dirty (lightly tested) few lines of Code, enabling to pass at least the certificate options for both, client and serverside for MY TLS session. Complete control over the transport channel properties would be appreciated. But that will do for now. 

```
        client_cert= '/myclientcert.pem'
        op = OpenProject(url="https://myopenproject/",
                         api_key="3.14159265359pi",
                         **{'verify': my_ca_root_certificate, 'cert': client_cert})
```