### PR TITLE
refactor: support filter value type as int

### DIFF
--- a/.github/workflows/test_cases.yml
+++ b/.github/workflows/test_cases.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy3.9", "pypy3.10", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test_cases.yml
+++ b/.github/workflows/test_cases.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.9, 3.8, 3.7, 3.6 ]
+        python-version: ["pypy3.9", "pypy3.10", "3.9", "3.10", "3.11", "3.12"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/pyopenproject/api_connection/requests/delete_request.py
+++ b/pyopenproject/api_connection/requests/delete_request.py
@@ -13,5 +13,5 @@ class DeleteRequest(Request):
         with requests.Session() as s:
             s.auth = HTTPBasicAuth(self.connection.api_user, self.connection.api_key)
             s.headers.update({'Content-Type': 'application/json;charset=utf-8'})
-            response = s.delete(url=self.connection.url_base + self.context)
+            response = s.delete(url=self.connection.url_base + self.context, **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/get_request.py
+++ b/pyopenproject/api_connection/requests/get_request.py
@@ -13,5 +13,5 @@ class GetRequest(Request):
         with requests.Session() as s:
             s.auth = HTTPBasicAuth(self.connection.api_user, self.connection.api_key)
             s.headers.update({"Content-Type": "application/hal+json"})
-            response = s.get(self.connection.url_base + self.context)
+            response = s.get(self.connection.url_base + self.context, **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/patch_request.py
+++ b/pyopenproject/api_connection/requests/patch_request.py
@@ -13,5 +13,5 @@ class PatchRequest(Request):
         with requests.Session() as s:
             s.auth = HTTPBasicAuth(self.connection.api_user, self.connection.api_key)
             s.headers.update({"Content-Type": "application/json"})
-            response = s.patch(self.connection.url_base + self.context, json=self.json)
+            response = s.patch(self.connection.url_base + self.context, json=self.json, **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/post_request.py
+++ b/pyopenproject/api_connection/requests/post_request.py
@@ -17,5 +17,6 @@ class PostRequest(Request):
                 url=self.connection.url_base + self.context,
                 json=self.json,
                 files=self.files,
-                data=self.data)
+                data=self.data,
+                **self.connection.request_args)
         return response

--- a/pyopenproject/api_connection/requests/put_request.py
+++ b/pyopenproject/api_connection/requests/put_request.py
@@ -13,5 +13,6 @@ class PutRequest(Request):
             self.connection.url_base + self.context,
             auth=HTTPBasicAuth(self.connection.api_user, self.connection.api_key),
             data=self.json,
-            headers=self.headers
+            headers=self.headers,
+            **self.connection.request_args
         )

--- a/pyopenproject/business/services/command/work_package/find_children.py
+++ b/pyopenproject/business/services/command/work_package/find_children.py
@@ -1,0 +1,22 @@
+from pyopenproject.api_connection.exceptions.request_exception import RequestError
+from pyopenproject.api_connection.requests.get_request import GetRequest
+from pyopenproject.business.exception.business_error import BusinessError
+from pyopenproject.business.services.command.work_package.work_package_command import WorkPackageCommand
+from pyopenproject.model import work_package as wp
+
+
+class FindChildren(WorkPackageCommand):
+    def __init__(self, connection, work_package):
+        super().__init__(connection)
+        self.work_package = work_package
+        self.obj_list=[]
+
+    def execute(self):
+        try:
+            if "children" in self.work_package.__dict__["_links"]:
+                for children in self.work_package.__dict__["_links"]["children"]:
+                    request = GetRequest(self.connection, f'{children["href"]}')
+                    self.obj_list.append(wp.WorkPackage(request.execute()))
+            return self.obj_list
+        except RequestError as re:
+            raise BusinessError(f"Error finding children for work package {self.work_package.id}") from re

--- a/pyopenproject/business/services/work_package_service_impl.py
+++ b/pyopenproject/business/services/work_package_service_impl.py
@@ -22,6 +22,7 @@ from pyopenproject.business.services.command.work_package.find_schema import Fin
 from pyopenproject.business.services.command.work_package.find_watchers import FindWatchers
 from pyopenproject.business.services.command.work_package.update import Update
 from pyopenproject.business.services.command.work_package.update_form import UpdateForm
+from pyopenproject.business.services.command.work_package.find_children import FindChildren
 from pyopenproject.business.work_package_service import WorkPackageService
 
 
@@ -106,3 +107,6 @@ class WorkPackageServiceImpl(WorkPackageService):
 
     def create_activity(self, work_package, comment, notify=None):
         return CreateActivity(self.connection, work_package, comment, notify).execute()
+
+    def find_children(self, work_package):
+        return list(FindChildren(self.connection, work_package).execute())

--- a/pyopenproject/business/util/filters.py
+++ b/pyopenproject/business/util/filters.py
@@ -21,10 +21,13 @@ class Filters(URLParameter):
             output += f"\"{self.value[i].name}\":"
             output += "{"
             output += f"\"operator\":\"{self.value[i].operator}\",\"values\":["
-            for j in range(len(self.value[i].values)):
-                if j != 0:
-                    output += ","
-                output += f"\"{self.value[i].values[j]}\""
+            if type(self.value[i].values) is int:
+                output += f"\"{str(self.value[i].values)}\""
+            else:
+                for j in range(len(self.value[i].values)):
+                    if j != 0:
+                        output += ","
+                    output += f"\"{self.value[i].values[j]}\""            
             output += "]}}"
             output += "," if len(self.value) != 1 and i != len(self.value)-1 else ""
         output += "]"

--- a/pyopenproject/model/connection.py
+++ b/pyopenproject/model/connection.py
@@ -6,13 +6,14 @@ class Connection:
     Class Configuration,
     represents the connection realized with the web application
     """
-    def __init__(self, url, apikey, user=None):
+    def __init__(self, url, apikey, user=None, **kwargs):
         """Constructor for class Connection
         :param url: The application url
         :param apikey: The apikey
         :param user: The user (optional)
         """
         self.url_base = url
+        self.request_args = kwargs
         self.api_user = "apikey" if user is None else user
         self.api_key = apikey
 

--- a/pyopenproject/openproject.py
+++ b/pyopenproject/openproject.py
@@ -35,10 +35,10 @@ from pyopenproject.model.connection import Connection
 
 class OpenProject:
 
-    def __init__(self, url, api_key, user=None):
-        self.conn = Connection(url=url, apikey=api_key) \
+    def __init__(self, url, api_key, user=None, **kwargs):
+        self.conn = Connection(url=url, apikey=api_key, **kwargs) \
             if user is None \
-            else Connection(url=url, user=user, apikey=api_key)
+            else Connection(url=url, user=user, apikey=api_key, **kwargs)
 
     def get_activity_service(self):
         return ActivityServiceImpl(self.conn)

--- a/tests/test_cases/membership_service_test.py
+++ b/tests/test_cases/membership_service_test.py
@@ -57,7 +57,7 @@ class MembershipServiceTestCase(OpenProjectTestCase):
             membership_to_create.__dict__['_links']['principal']["href"])
         membership_aux = Membership(membership.__dict__.copy())
         updated_form = self.membershipSer.update_form(membership_aux)
-        self.assertEqual({'_links': {'roles': [{'href': '/api/v3/roles/5', 'title': 'Reader'}]}},
+        self.assertEqual({'_links': {'roles': [{'href': '/api/v3/roles/5', 'title': 'Reader'}]}, '_meta': {'notificationMessage': {'format': 'markdown', 'html': '', 'raw': None}}},
                          updated_form._embedded['payload'])
         membership = self.membershipSer.find(membership)
         self.assertIsNotNone(membership)

--- a/tests/test_cases/principal_service_test.py
+++ b/tests/test_cases/principal_service_test.py
@@ -17,7 +17,7 @@ class PrincipalServiceTestCase(OpenProjectTestCase):
 
     def test_find_all(self):
         principals = self.principalSer.find_all(filters=None)
-        self.assertEqual(1, len(principals))
+        self.assertEqual(2, len(principals))
 
     def test_filters(self):
         # Filter member cant be tested with default user


### PR DESCRIPTION
if value type as int, don't split it to char.
value=22, "values": ["22"] 
value="22", "values": ["2","2"]